### PR TITLE
chore: update device-test-core library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "unidecode >= 1.3.6, < 2.0.0",
-  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.10.1",
+  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
 ]
 
 [project.optional-dependencies]
@@ -33,13 +33,13 @@ all = [
     "robotframework-devicelibrary[local]",
 ]
 ssh = [
-    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.1",
+    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
 ]
 local = [
-    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.1",
+    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
 ]
 docker = [
-    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.1",
+    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
 ]
 
 test = [


### PR DESCRIPTION
Update device-test-core library to fix a bug with the Docker adapter where the log_output option of the `Execute Command` as not respected and resulted in printing out the command to the log output