### PR TITLE
feat: new keyword to check if symlink exists or not

### DIFF
--- a/DeviceLibrary/DeviceLibrary.py
+++ b/DeviceLibrary/DeviceLibrary.py
@@ -876,7 +876,6 @@ class DeviceLibrary:
         if target_exists:
             self.current.assert_command(f"test -e '{path}'", **kwargs)
 
-
     @keyword("Symlink Should Not Exist")
     def assert_not_symlink_exists(self, path: str, **kwargs):
         """Check if a symlink does not exists


### PR DESCRIPTION
Add `Symlink Should Exist` and `Symlink Should Not Exist` keywords.

Quick test case to verify how the new keywords work.

```robot
Test symlink Keywords
    Execute Command    mkdir -p /tests && touch /tests/foo
    Execute Command    ln -sf /tests/foo /tests/foo-link
    Execute Command    ln -sf /tests/bar /tests/bar-link

    Symlink Should Exist    /tests/foo-link
    Run Keyword And Expect Error    *    Symlink Should Exist    /tests/bar-link    # fails because the target doesn't exist
    Symlink Should Exist    /tests/bar-link    target_exists=False    # ignores if the target exists
    Symlink Should Not Exist    /tests/foo    # it is a file
```