### PR TITLE
fix: update device-test-core to fix empty docker output bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "unidecode >= 1.3.6, < 2.0.0",
-  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.14.2",
+  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.14.3",
 ]
 
 [project.optional-dependencies]
@@ -33,13 +33,13 @@ all = [
     "robotframework-devicelibrary[local]",
 ]
 ssh = [
-    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.2",
+    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.3",
 ]
 local = [
-    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.2",
+    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.3",
 ]
 docker = [
-    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.2",
+    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.14.3",
 ]
 
 test = [


### PR DESCRIPTION
This is hopefully fixing a difficult bug in the underlying docker-py where the execute_command (in the docker adapter) sometimes returns empty stdout and stderr.

The root cause is likely due to the buffered sockets being used, which are not being read correctly in some situations and can lose information. This has only ever been observed in the Github Runner.